### PR TITLE
Example of unstable-allowing context manager.

### DIFF
--- a/numcodecs/blosc.pyx
+++ b/numcodecs/blosc.pyx
@@ -17,6 +17,8 @@ from .compat_ext import Buffer
 from .compat import ensure_contiguous_ndarray
 from .abc import Codec
 
+from .utils import unstable
+
 
 cdef extern from "blosc.h":
     cdef enum:
@@ -580,6 +582,7 @@ class Blosc(Codec):
         return decompress(buf, out)
 
     def decode_partial(self, buf, int start, int nitems, int typesize=0, int encoding_size=0, out=None):
+        unstable()
         buf = ensure_contiguous_ndarray(buf, self.max_buffer_size)
         return decompress_partial(buf, start, nitems,
                 typesize, encoding_size, dest=out)

--- a/numcodecs/tests/test_blosc.py
+++ b/numcodecs/tests/test_blosc.py
@@ -65,7 +65,11 @@ def test_encode_decode():
                                    else pytest.param(x, marks=[pytest.mark.xfail])
                                    for x in arrays])
 def test_partial_decode(codec, array):
-    check_encode_decode_partial(array, codec)
+
+
+    from numcodecs.utils import allow_unstable
+    with allow_unstable():
+        check_encode_decode_partial(array, codec)
 
 
 def test_config():

--- a/numcodecs/utils.py
+++ b/numcodecs/utils.py
@@ -1,0 +1,36 @@
+from contextlib import contextmanager
+import warnings
+
+class NumcodecsUnstableWarning(FutureWarning):
+    """
+    Exception raise by an experimental feature in this numcodec
+
+    Wrap code in :any:`allow_unstable` to let code dirrectly (or indirectly),
+    use unstable features. 
+    """
+
+warnings.filterwarnings('error', category=NumcodecsUnstableWarning)
+
+@contextmanager
+def allow_unstable(action='default'):
+    """
+    This context manager has to be used in any place where unstable completer
+    behavior and API may be called.
+
+    >>> with allow_unstable():
+    ...     numcodecs.do_experimental_things() # works
+
+    >>> numcodecs.do_experimental_things() # raises.
+
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(action, category=NumcodecsUnstableWarning)
+        yield
+
+
+def unstable():
+    warnings.warn(
+            "You are (in)directly using an unstable feature, use the "
+            "``allow_unstable()`` context manager."
+    , category=NumcodecsUnstableWarning, stacklevel=2)
+


### PR DESCRIPTION
The advantage of using warnings instead of globals is performance and
the ability to also still get the warning printed by default.


